### PR TITLE
fix: make sure digest is those 32 bytes only

### DIFF
--- a/b288702/verify_all.sh
+++ b/b288702/verify_all.sh
@@ -93,7 +93,7 @@ params_file=$(echo -e "$split_output" | grep -o "v${version}-.*\.params")
 # Verify groth keys checksums.
 log 'verifying .vk checksum'
 vk_digest=$(b2sum $vk_file | head -c 32)
-vk_digest_json=$(grep -A 2 $vk_file filecoin-proofs/parameters.json | grep 'digest' | tr -d '[:punct:]' | awk '{print $2}')
+vk_digest_json=$(grep -A 2 $vk_file filecoin-proofs/parameters.json | grep 'digest' | tr -d '[:punct:]' | awk '{print $2}' | head -c 32)
 
 if [[ $vk_digest == $vk_digest_json ]]; then
     log "${green}success:${off} .vk digests match"
@@ -105,7 +105,7 @@ fi
 # Verify .params checksum.
 log 'verifying .params checksum'
 params_digest=$(b2sum $params_file | head -c 32)
-params_digest_json=$(grep -A 2 $params_file filecoin-proofs/parameters.json | grep 'digest' | tr -d '[:punct:]' | awk '{print $2}')
+params_digest_json=$(grep -A 2 $params_file filecoin-proofs/parameters.json | grep 'digest' | tr -d '[:punct:]' | awk '{print $2}' | head -c 32)
 
 if [[ $params_digest == $params_digest_json ]]; then
     log "${green}success:${off} .params digests match"


### PR DESCRIPTION
Remove a potential new line at the end of the command and make sure
the digest is 32 bytes without a newline before comparing it.

Also fix a typo in the README.

The script has plenty of [ShellCheck](https://www.shellcheck.net/) warnings,
but I guess that isn't a priority for now.

One FYI (I think it's always cool to hear about random shell tools): Things like
`tr -d '[:punct:]' | awk '{print $2}'` can also be written (in those cases) as something
like `cut -d '"' -f 4`, which is shorter and needs less tools.