### PR TITLE
feat: add verification for split-keys splitting

### DIFF
--- a/b288702/verify_all.sh
+++ b/b288702/verify_all.sh
@@ -93,7 +93,7 @@ params_file=$(echo -e "$split_output" | grep -o "v${version}-.*\.params")
 # Verify groth keys checksums.
 log 'verifying .vk checksum'
 vk_digest=$(b2sum $vk_file | head -c 32)
-vk_digest_json=$(grep -A 2 $vk_file filecoin-proofs/parameters.json | grep 'digest' | tr -d '[:punct:]' | awk '{print $2}')
+vk_digest_json=$(grep -A 2 $vk_file filecoin-proofs/parameters.json | grep 'digest' | tr -d '[:punct:]' | awk '{print $2}' | head -c 32)
 
 if [[ $vk_digest == $vk_digest_json ]]; then
     log "${green}success:${off} .vk digests match"
@@ -105,7 +105,7 @@ fi
 # Verify .params checksum.
 log 'verifying .params checksum'
 params_digest=$(b2sum $params_file | head -c 32)
-params_digest_json=$(grep -A 2 $params_file filecoin-proofs/parameters.json | grep 'digest' | tr -d '[:punct:]' | awk '{print $2}')
+params_digest_json=$(grep -A 2 $params_file filecoin-proofs/parameters.json | grep 'digest' | tr -d '[:punct:]' | awk '{print $2}' | head -c 32)
 
 if [[ $params_digest == $params_digest_json ]]; then
     log "${green}success:${off} .params digests match"


### PR DESCRIPTION
Verify that the split files are an actual subset of the original
trusted setup files.

This PR contains also the commit from https://github.com/filecoin-project/phase2-attestations/pull/5,
but I wanted to get this PR opened in order to move faster.