### PR TITLE
Update URLs and commit hashes.

### DIFF
--- a/b288702/README.md
+++ b/b288702/README.md
@@ -31,15 +31,15 @@ The following are requirements for participating in Filecoin's mainnet Phase 2. 
 ```bash
 $ git clone https://github.com/filecoin-project/rust-fil-proofs.git
 $ cd rust-fil-proofs
-$ git checkout 8e7c5a0
+$ git checkout 6e38487
 $ cargo build --release --bin phase2 && cp target/release/phase2 .
 ```
 
 2. Download checksums file and verification script:
 
 ```bash
-$ curl -O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/master/b288702/b288702.b2sums \
--O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/master/b288702/verify_all.sh && chmod +x verify_all.sh
+$ curl -O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/eff79d7/b288702/b288702.b2sums \
+-O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/eff79d7/b288702/verify_all.sh && chmod +x verify_all.sh
 ```
 
 3. Verify Phase2 contributions:

--- a/b288702/verify_all.sh
+++ b/b288702/verify_all.sh
@@ -44,8 +44,10 @@ fi
 log 'generating initial params'
 ./phase2 new --${proof} --${sector_size}gib
 
+# Rename initial params file to replace commit hash at time of ceremony start
+# with that of the current release (which should be checked out), so verification will succeed.
 initial_large="${proof}_poseidon_${sector_size}gib_b288702_0_large"
-mv ${proof}_poseidon_${sector_size}gib_8e7c5a0_0_large $initial_large
+mv ${proof}_poseidon_${sector_size}gib_$(git rev-parse --short=7 HEAD)_0_large $initial_large
 
 # Verify checksum of generated initial params.
 log 'verifying initial params checksum'


### PR DESCRIPTION
Use explicit commit hash for local GitHub link, and use v5.0.0 commit hash when checking out `rust-fil-proofs`.