### PR TITLE
Add link to rust-fil-proofs installation notes

### DIFF
--- a/b288702/README.md
+++ b/b288702/README.md
@@ -26,7 +26,7 @@ The following are requirements for participating in Filecoin's mainnet Phase 2. 
 
 **Note: We recommend you use a machine with 96 cores and 120GB of RAM for running verification**
 
-1. Build `rust-fil-proofs`, please also check its [Rust installation instructions](https://github.com/filecoin-project/rust-fil-proofs/blob/6e38487293a2ec063688acb4a414600b1c0654f9/README.md#install-and-configure-rust):
+1. Build `rust-fil-proofs`, please also check its [Rust installation/build instructions](https://github.com/filecoin-project/rust-fil-proofs/blob/6e38487293a2ec063688acb4a414600b1c0654f9/README.md#install-and-configure-rust):
 
 ```bash
 $ git clone https://github.com/filecoin-project/rust-fil-proofs.git

--- a/b288702/README.md
+++ b/b288702/README.md
@@ -26,7 +26,7 @@ The following are requirements for participating in Filecoin's mainnet Phase 2. 
 
 **Note: We recommend you use a machine with 96 cores and 120GB of RAM for running verification**
 
-1. Build `rust-fil-proofs`:
+1. Build `rust-fil-proofs`, please also check its [Rust installation instructions](https://github.com/filecoin-project/rust-fil-proofs/blob/6e38487293a2ec063688acb4a414600b1c0654f9/README.md#install-and-configure-rust):
 
 ```bash
 $ git clone https://github.com/filecoin-project/rust-fil-proofs.git


### PR DESCRIPTION
rust-fil-proofs needs to have Rust installed properly.