### PR TITLE
Verify G1 subgroup and allow verifying contribs independently.

### DIFF
--- a/b288702/README.md
+++ b/b288702/README.md
@@ -40,7 +40,11 @@ $ cargo build --release --bin phase2 && cp target/release/phase2 .
 
 ```bash
 $ curl -O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/b80d1f8/b288702/b288702.b2sums \
--O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/b80d1f8/b288702/verify_all.sh && chmod +x verify_all.sh
+-O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/b80d1f8/b288702/verify_all.sh \
+-O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/b80d1f8/b288702/verify_initial.sh \
+-O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/b80d1f8/b288702/verify_contrib.sh \
+-O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/b80d1f8/b288702/verify_final.sh \
+&& chmod +x verify_all.sh verify_initial.sh verify_contrib.sh verify_final.sh
 ```
 
 3. Verify Phase2 contributions:

--- a/b288702/README.md
+++ b/b288702/README.md
@@ -28,10 +28,11 @@ The following are requirements for participating in Filecoin's mainnet Phase 2. 
 
 1. Build `rust-fil-proofs`, please also check its [Rust installation/build instructions](https://github.com/filecoin-project/rust-fil-proofs/blob/6e38487293a2ec063688acb4a414600b1c0654f9/README.md#install-and-configure-rust):
 
+You will check out the commit corresponding to the [filecoin-proofs-v5.1.1](https://github.com/filecoin-project/rust-fil-proofs/releases/tag/filecoin-proofs-v5.1.1) tag, named explicitly below to ensure you are using the authoritative verification code.
 ```bash
 $ git clone https://github.com/filecoin-project/rust-fil-proofs.git
 $ cd rust-fil-proofs
-$ git checkout 6e38487
+$ git checkout a700f68
 $ cargo build --release --bin phase2 && cp target/release/phase2 .
 ```
 
@@ -44,7 +45,15 @@ $ curl -O https://raw.githubusercontent.com/filecoin-project/phase2-attestations
 
 3. Verify Phase2 contributions:
 
-In order to run the verifcation, you will need to download the relevant Phase 1 file for the circuit and run the verification script for that specific circuit. The verification script will verify all Phase 2 contributions made to the Groth16 parameters for a circuit of that specific size and check that the verified Groth16 parameters are being used by the Filecoin network. The commands and associated Phase 1 file for each circuit are listed below.
+In order to run the verifcation, you will need to download the relevant Phase 1 file for the circuit and run the
+verification script for that specific circuit. The verification script will verify all Phase 2 contributions made to the
+Groth16 parameters for a circuit of that specific size and check that the verified Groth16 parameters are being used by
+the Filecoin network. The commands and associated Phase 1 file for each circuit are listed below.
+
+Running `verify_all.sh` as illustrated here is very time-consuming, especially for the large circuits (SDR-PoRep and
+Window-PoSt). These commands are provided for reference, to clarify what must be verified. In practice, we recommend
+that verifiers follow the instructions in the next section, **Verify all contributions individually**.
+
 
 **Winning-PoSt**
 
@@ -53,7 +62,6 @@ In order to run the verifcation, you will need to download the relevant Phase 1 
 ```
 $ curl -O https://trusted-setup.s3.amazonaws.com/challenge19/phase1radix2m19
 $ ./verify_all.sh winning 32
-…
 $ ./verify_all.sh winning 64
 ```
 
@@ -64,10 +72,156 @@ $ ./verify_all.sh winning 64
 ```bash
 $ curl -O https://trusted-setup.s3.amazonaws.com/challenge19/phase1radix2m27
 $ ./verify_all.sh sdr 32
-…
 $ ./verify_all.sh sdr 64
-…
 $ ./verify_all.sh window 32
-…
 $ ./verify_all.sh window 64
 ```
+
+
+### Verify contributions individually (suggested alternative to section 3. above)
+
+If run sequentially, as presented below, the following command will take a very long time (months).
+
+We encourage verifiers to split the command into smaller pieces and run them in parallel on multiple machines. Each
+sub-command can be run independently, and each must be run at least once. Every sub-command must succeed for the
+verification to succeed.
+
+No precautions have been taken to ensure multiple processes running against the same storage will not clash with each
+other. Because each verification step requires two sequential contribution files, groups of contributions verified using
+the same storage should be verified sequentially. Otherwise, you risk two adjacent verifications simultaneously
+requesting the same file.
+
+There is one additional dependency: `verify_initial.sh` must be run before `verify_contrib.sh` for the first contrib of
+every circuit. This is because the 'before' parameters for the first transition cannot be downloaded: they must be
+deterministically generated from the target circuit.
+
+```bash
+bash -c '
+  set -e
+  curl -O https://trusted-setup.s3.amazonaws.com/challenge19/phase1radix2m19
+
+  ./verify_initial.sh winning 32
+  ./verify_contrib.sh winning 32 1
+  ./verify_contrib.sh winning 32 2
+  ./verify_contrib.sh winning 32 3
+  ./verify_contrib.sh winning 32 4
+  ./verify_contrib.sh winning 32 5
+  ./verify_contrib.sh winning 32 6
+  ./verify_contrib.sh winning 32 7
+  ./verify_contrib.sh winning 32 8
+  ./verify_contrib.sh winning 32 9
+  ./verify_contrib.sh winning 32 10
+  ./verify_contrib.sh winning 32 11
+  ./verify_contrib.sh winning 32 12
+  ./verify_contrib.sh winning 32 13
+  ./verify_contrib.sh winning 32 14
+  ./verify_contrib.sh winning 32 15
+  ./verify_contrib.sh winning 32 16
+  ./verify_contrib.sh winning 32 17
+  ./verify_contrib.sh winning 32 18
+  ./verify_contrib.sh winning 32 19
+  ./verify_contrib.sh winning 32 20
+  ./verify_final.sh winning 32
+
+  ./verify_initial.sh winning 64
+  ./verify_contrib.sh winning 64 1
+  ./verify_contrib.sh winning 64 2
+  ./verify_contrib.sh winning 64 3
+  ./verify_contrib.sh winning 64 4
+  ./verify_contrib.sh winning 64 5
+  ./verify_contrib.sh winning 64 6
+  ./verify_contrib.sh winning 64 7
+  ./verify_contrib.sh winning 64 8
+  ./verify_contrib.sh winning 64 9
+  ./verify_contrib.sh winning 64 10
+  ./verify_contrib.sh winning 64 11
+  ./verify_contrib.sh winning 64 12
+  ./verify_contrib.sh winning 64 13
+  ./verify_contrib.sh winning 64 14
+  ./verify_contrib.sh winning 64 15
+  ./verify_contrib.sh winning 64 16
+  ./verify_contrib.sh winning 64 17
+  ./verify_contrib.sh winning 64 18
+  ./verify_contrib.sh winning 64 19
+  ./verify_contrib.sh winning 64 20
+  ./verify_final.sh winning 64
+
+  curl -O https://trusted-setup.s3.amazonaws.com/challenge19/phase1radix2m27
+
+  ./verify_initial.sh sdr 32
+  ./verify_contrib.sh sdr 32 1
+  ./verify_contrib.sh sdr 32 2
+  ./verify_contrib.sh sdr 32 3
+  ./verify_contrib.sh sdr 32 4
+  ./verify_contrib.sh sdr 32 5
+  ./verify_contrib.sh sdr 32 6
+  ./verify_contrib.sh sdr 32 7
+  ./verify_contrib.sh sdr 32 8
+  ./verify_contrib.sh sdr 32 9
+  ./verify_contrib.sh sdr 32 10
+  ./verify_contrib.sh sdr 32 11
+  ./verify_contrib.sh sdr 32 12
+  ./verify_contrib.sh sdr 32 13
+  ./verify_contrib.sh sdr 32 14
+  ./verify_contrib.sh sdr 32 15
+  ./verify_contrib.sh sdr 32 16
+  ./verify_contrib.sh sdr 32 17
+  ./verify_final.sh sdr 32
+
+  ./verify_initial.sh sdr 64
+  ./verify_contrib.sh sdr 64 1
+  ./verify_contrib.sh sdr 64 2
+  ./verify_contrib.sh sdr 64 3
+  ./verify_contrib.sh sdr 64 4
+  ./verify_contrib.sh sdr 64 5
+  ./verify_contrib.sh sdr 64 6
+  ./verify_contrib.sh sdr 64 7
+  ./verify_contrib.sh sdr 64 8
+  ./verify_contrib.sh sdr 64 9
+  ./verify_contrib.sh sdr 64 10
+  ./verify_contrib.sh sdr 64 11
+  ./verify_contrib.sh sdr 64 12
+  ./verify_contrib.sh sdr 64 13
+  ./verify_contrib.sh sdr 64 14
+  ./verify_contrib.sh sdr 64 15
+  ./verify_contrib.sh sdr 64 16
+  ./verify_final.sh sdr 64
+
+  ./verify_initial.sh window 32
+  ./verify_contrib.sh window 32 1
+  ./verify_contrib.sh window 32 2
+  ./verify_contrib.sh window 32 3
+  ./verify_contrib.sh window 32 4
+  ./verify_contrib.sh window 32 5
+  ./verify_contrib.sh window 32 6
+  ./verify_contrib.sh window 32 7
+  ./verify_contrib.sh window 32 8
+  ./verify_contrib.sh window 32 9
+  ./verify_contrib.sh window 32 10
+  ./verify_contrib.sh window 32 11
+  ./verify_contrib.sh window 32 12
+  ./verify_contrib.sh window 32 13
+  ./verify_contrib.sh window 32 14
+  ./verify_contrib.sh window 32 15
+  ./verify_final.sh window 32
+
+  ./verify_initial.sh window 64
+  ./verify_contrib.sh window 64 1
+  ./verify_contrib.sh window 64 2
+  ./verify_contrib.sh window 64 3
+  ./verify_contrib.sh window 64 4
+  ./verify_contrib.sh window 64 5
+  ./verify_contrib.sh window 64 6
+  ./verify_contrib.sh window 64 7
+  ./verify_contrib.sh window 64 8
+  ./verify_contrib.sh window 64 9
+  ./verify_contrib.sh window 64 10
+  ./verify_contrib.sh window 64 11
+  ./verify_contrib.sh window 64 12
+  ./verify_contrib.sh window 64 13
+  ./verify_contrib.sh window 64 14
+  ./verify_contrib.sh window 64 15
+  ./verify_final.sh window 64
+'
+```
+

--- a/b288702/verify_contrib.sh
+++ b/b288702/verify_contrib.sh
@@ -83,6 +83,3 @@ fi
 
 ./phase2 verify $file
 log "${green}success:${off} verified contribution: ${i}"
-# Free some disk space, delete the verified patameters, keep the
-# contributions and their signatures
-[[ $i -gt 1 ]] && rm ${proof}_poseidon_${sector_size}gib_b288702_$((i-1))_small_raw

--- a/b288702/verify_contrib.sh
+++ b/b288702/verify_contrib.sh
@@ -55,7 +55,7 @@ url_base='https://trusted-setup.s3.amazonaws.com/phase2-mainnet'
 # Verify phase2 contributions.
 log "verifying contribution: ${contrib}"
 
-prev=$n-1
+prev=$((contrib - 1))
 prev_file="${proof}_poseidon_${sector_size}gib_b288702_${prev}_small_raw"
 if [[ ! -f ${prev_file} ]]; then
     log "downloading params: ${file}"

--- a/b288702/verify_contrib.sh
+++ b/b288702/verify_contrib.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -e
+
+proof="$1"
+sector_size="$2"
+version='28'
+contrib="$3"
+
+echo "proof: $proof; sector_size: $sector_size; contrib: $contrib"
+
+magenta='\u001b[35;1m'
+red='\u001b[31;1m'
+green='\u001b[32;1m'
+off='\u001b[0m'
+
+function log() {
+    echo -e "${magenta}[phase2_verify_contrib.sh]${off} $1"
+}
+
+function error() {
+    echo -e "${magenta}[phase2_verify_contrib.sh] ${red}error:${off} $1"
+}
+
+if [[ $proof != 'winning' && $proof != 'sdr' && $proof != 'window' ]]; then
+    error "invalid proof: '${proof}'"
+    exit 1
+fi
+
+if [[ $sector_size != '32' && $sector_size != '64' ]]; then
+    error "invalid sector-size: '${sector_size}'"
+    exit 1
+fi
+
+# The number of phase2 contributions.
+if [[ $proof == 'winning' ]]; then
+    n='20'
+elif [[ $proof == 'window' ]]; then
+    n='15'
+elif [[ $sector_size == '32' ]]; then
+    n='17'
+else
+    n='16'
+fi
+
+if [[ -z $contrib || $contrib > $n ]]; then
+    error "invalid contrib: ${contrib}"
+    exit 1
+else
+    echo "contrib: ${contrib}"
+fi
+
+url_base='https://trusted-setup.s3.amazonaws.com/phase2-mainnet'
+
+# Verify phase2 contributions.
+log "verifying contribution: ${i}"
+
+prev=$n-1
+prev_file="${proof}_poseidon_${sector_size}gib_b288702_${prev}_small_raw"
+if [[ ! -f ${prev_file} ]]; then
+    log "downloading params: ${file}"
+    curl --progress-bar -O ${url_base}/${prev_file}
+fi
+# Verify checksum even if file was present, in case of incomplete download or corruption.
+# This is especially relevant if another process might have initiated a download now in process.
+log 'verifying downloaded params checksum'
+grep $prev_file b288702.b2sums | b2sum -c
+
+
+file="${proof}_poseidon_${sector_size}gib_b288702_${i}_small_raw"
+if [[ ! -f ${file} ]]; then
+    log "downloading params: ${file}"
+    curl --progress-bar -O ${url_base}/${file}
+fi
+log 'verifying downloaded params checksum'
+grep $file b288702.b2sums | b2sum -c
+
+contrib="${file}.contrib"
+if [[ ! -f ${contrib} ]]; then
+    log "downloading contrib: ${contrib}"
+    curl --progress-bar -O ${url_base}/${contrib}
+fi
+
+./phase2 verify $file
+log "${green}success:${off} verified contribution: ${i}"
+# Free some disk space, delete the verified patameters, keep the
+# contributions and their signatures
+[[ $i -gt 1 ]] && rm ${proof}_poseidon_${sector_size}gib_b288702_$((i-1))_small_raw

--- a/b288702/verify_contrib.sh
+++ b/b288702/verify_contrib.sh
@@ -43,7 +43,7 @@ else
     n='16'
 fi
 
-if [[ -z $contrib || $contrib > $n ]]; then
+if [[ -z $contrib || $contrib  -gt $n ]]; then
     error "invalid contrib: ${contrib}"
     exit 1
 else

--- a/b288702/verify_contrib.sh
+++ b/b288702/verify_contrib.sh
@@ -53,7 +53,7 @@ fi
 url_base='https://trusted-setup.s3.amazonaws.com/phase2-mainnet'
 
 # Verify phase2 contributions.
-log "verifying contribution: ${i}"
+log "verifying contribution: ${contrib}"
 
 prev=$n-1
 prev_file="${proof}_poseidon_${sector_size}gib_b288702_${prev}_small_raw"
@@ -67,7 +67,7 @@ log 'verifying downloaded params checksum'
 grep $prev_file b288702.b2sums | b2sum -c
 
 
-file="${proof}_poseidon_${sector_size}gib_b288702_${i}_small_raw"
+file="${proof}_poseidon_${sector_size}gib_b288702_${contrib}_small_raw"
 if [[ ! -f ${file} ]]; then
     log "downloading params: ${file}"
     curl --progress-bar -O ${url_base}/${file}
@@ -82,4 +82,4 @@ if [[ ! -f ${contrib} ]]; then
 fi
 
 ./phase2 verify $file
-log "${green}success:${off} verified contribution: ${i}"
+log "${green}success:${off} verified contribution: ${contrib}"

--- a/b288702/verify_contribution.sh
+++ b/b288702/verify_contribution.sh
@@ -6,7 +6,7 @@ proof="$1"
 sector_size="$2"
 version='28'
 
-dir=$(dirname "$0")
+contrib="$3"
 
 magenta='\u001b[35;1m'
 red='\u001b[31;1m'
@@ -31,24 +31,7 @@ if [[ $sector_size != '32' && $sector_size != '64' ]]; then
     exit 1
 fi
 
-# The number of phase2 contributions.
-if [[ $proof == 'winning' ]]; then
-    n='20'
-elif [[ $proof == 'window' ]]; then
-    n='15'
-elif [[ $sector_size == '32' ]]; then
-    n='17'
-else
-    n='16'
+if
+    [[ $contrib == 'g1-only' ]]; then
+    g1=true
 fi
-
-$dir/verify_initial.sh $proof $sector_size
-
-# Verify phase2 contributions.
-for i in $(seq 1 $n); do
-    $dir/verify_contrib.sh $proof $sector_size $i
-done
-
-$dir/verify_final.sh $proof $sector_size
-
-log "${green}success:${off} finished verifying all phase2 parameters"

--- a/b288702/verify_final.sh
+++ b/b288702/verify_final.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -e
+
+proof="$1"
+sector_size="$2"
+version='28'
+
+dir=$(dirname "$0")
+
+magenta='\u001b[35;1m'
+red='\u001b[31;1m'
+green='\u001b[32;1m'
+off='\u001b[0m'
+
+function log() {
+    echo -e "${magenta}[phase2_verify_all.sh]${off} $1"
+}
+
+function error() {
+    echo -e "${magenta}[phase2_verify_all.sh] ${red}error:${off} $1"
+}
+
+if [[ $proof != 'winning' && $proof != 'sdr' && $proof != 'window' ]]; then
+    error "invalid proof: '${proof}'"
+    exit 1
+fi
+
+if [[ $sector_size != '32' && $sector_size != '64' ]]; then
+    error "invalid sector-size: '${sector_size}'"
+    exit 1
+fi
+
+# The number of phase2 contributions.
+if [[ $proof == 'winning' ]]; then
+    n='20'
+elif [[ $proof == 'window' ]]; then
+    n='15'
+elif [[ $sector_size == '32' ]]; then
+    n='17'
+else
+    n='16'
+fi
+
+$dir/verify_contrib.sh $proof $sector_size $n
+
+file="${proof}_poseidon_${sector_size}gib_b288702_${n}_small_raw"
+
+final_raw="$file"
+final_nonraw=$(echo $final_raw | sed 's/_raw$//')
+final_large=$(echo $final_nonraw | sed 's/small$/large/')
+
+# Convert phase2 params into Groth16 keys.
+log 'reformatting final params'
+_convert_output="$(./phase2 convert $final_raw)"
+
+log 'merging final params'
+_merge_output="$(./phase2 merge $final_nonraw $initial_large)"
+
+log 'extracting groth16 keys'
+split_output="$(./phase2 split-keys $final_large)"
+vk_file=$(echo -e "$split_output" | grep -o "v${version}-.*\.vk")
+params_file=$(echo -e "$split_output" | grep -o "v${version}-.*\.params")
+contribs_file=$(echo -e "$split_output" | grep -o "v${version}-.*\.contribs")
+
+# Verify groth keys checksums.
+log 'verifying .vk checksum'
+vk_digest=$(b2sum $vk_file | head -c 32)
+vk_digest_json=$(grep -A 2 $vk_file filecoin-proofs/parameters.json | grep 'digest' | tr -d '[:punct:]' | awk '{print $2}' | head -c 32)
+
+if [[ $vk_digest == $vk_digest_json ]]; then
+    log "${green}success:${off} .vk digests match"
+else
+    error '.vk digests do not match'
+    exit 1
+fi
+
+# Verify that the .vk file is extracted from the trusted setup phase2 file
+log 'verifying .vk is a subset of phase2'
+vk_size=$(wc --bytes < $vk_file)
+final_large_vk_digest=$(head --bytes $vk_size $final_large | b2sum | head -c 32)
+if [[ $vk_digest == $final_large_vk_digest ]]; then
+    log "${green}success:${off} .vk is a subset of phase2"
+else
+    error '.vk is not a subset of phase2'
+    exit 1
+fi
+
+# Verify .params checksum.
+log 'verifying .params checksum'
+params_digest=$(b2sum $params_file | head -c 32)
+params_digest_json=$(grep -A 2 $params_file filecoin-proofs/parameters.json | grep 'digest' | tr -d '[:punct:]' | awk '{print $2}' | head -c 32)
+
+if [[ $params_digest == $params_digest_json ]]; then
+    log "${green}success:${off} .params digests match"
+else
+    error '.params digests do not match'
+    exit 1
+fi
+
+# Verify that the trusted setup phase2 file can be re-assembled from its parts
+log 'verifying .params is a subset of phase2'
+combined_digest=$(cat $params_file $contribs_file | b2sum | head --bytes 32)
+final_large_digest=$(b2sum $final_large | head --bytes 32)
+if [[ $combined_digest == $final_large_digest ]]; then
+    log "${green}success:${off} .params is a subset of phase2"
+else
+    error '.params is not a subset of phase2'
+    exit 1
+fi
+
+log "${green}success:${off} finished verifying phase2 final parameters"

--- a/b288702/verify_final.sh
+++ b/b288702/verify_final.sh
@@ -42,6 +42,7 @@ else
     n='16'
 fi
 
+initial_large="${proof}_poseidon_${sector_size}gib_b288702_0_large"
 file="${proof}_poseidon_${sector_size}gib_b288702_${n}_small_raw"
 
 final_raw="$file"

--- a/b288702/verify_final.sh
+++ b/b288702/verify_final.sh
@@ -42,8 +42,6 @@ else
     n='16'
 fi
 
-$dir/verify_contrib.sh $proof $sector_size $n
-
 file="${proof}_poseidon_${sector_size}gib_b288702_${n}_small_raw"
 
 final_raw="$file"


### PR DESCRIPTION
This PR changes the commit specified so we will get full (expensive) G1 subgroup verification when verifying a contribution. It does not (yet?) expose the ability to suppress this verification from the provided scripts, nor does it suggest a method of performing only G1 subgroup verification.

Instead, at @ribasushi's suggestion (he will be testing the verification process fully), I provided an expanded command composed of all atomic commands required to fully verify all contributions for all circuits. The idea is that a verifier can break this list apart and parallelize as much as necessary.

I refactored the script into parts to allow this. I may or may not have introduced errors in the process — so review and some testing (try the small 'winning' circuits) would be extremely useful, @vmx.

My description in the README may also not be good enough yet, but I don't think we should let that block @ribasushi from beginning the verification process. Improved explanation is one of the expected outcomes of his process anyway. Any contributions to formatting, wording, or content are welcome.

I will not have much or any time to work on this for the rest of the day. My hope is that @ribasushi will be able to get going on this tomorrow, so if others can help get it across the line in their morning can get it across the line while I sleep, that would be great.

Again: this needs careful review with consideration of the total process. I think it's sound, but have not had time to convince myself in detail.