### PR TITLE
Update commit hash in curl script links.

### DIFF
--- a/b288702/README.md
+++ b/b288702/README.md
@@ -39,11 +39,11 @@ $ cargo build --release --bin phase2 && cp target/release/phase2 .
 2. Download checksums file and verification script:
 
 ```bash
-$ curl -O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/108b5af/b288702/b288702.b2sums \
--O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/108b5af/b288702/verify_all.sh \
--O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/108b5af/b288702/verify_initial.sh \
--O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/108b5af/b288702/verify_contrib.sh \
--O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/108b5af/b288702/verify_final.sh \
+$ curl -O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/51ddc5d/b288702/b288702.b2sums \
+-O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/51ddc5d/b288702/verify_all.sh \
+-O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/51ddc5d/b288702/verify_initial.sh \
+-O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/51ddc5d/b288702/verify_contrib.sh \
+-O https://raw.githubusercontent.com/filecoin-project/phase2-attestations/51ddc5d/b288702/verify_final.sh \
 && chmod +x verify_all.sh verify_initial.sh verify_contrib.sh verify_final.sh
 ```
 


### PR DESCRIPTION
`51ddc5d` points to the commit which was the head of `master` at the time this PR was created. Once this PR merges, the verification scripts will be fixed at the intended version.

Since the scripts are in the subdirectory of this particular setup, we could also possibly dispense with the commit-based versioning. Presumably future setups will have their own subdirectories and new copies of the scripts, in which case, incremental improvements to any of the scripts could be deployed more simply if we assume `master` will always have the most recent correct verification script _for each historical setup_ .