### PR TITLE
chore: fix typo in log message

### DIFF
--- a/b288702/download_prereqs_for_contrib.sh
+++ b/b288702/download_prereqs_for_contrib.sh
@@ -109,7 +109,7 @@ if [[ $contrib -gt 1 ]]; then
     prev=$((contrib - 1))
     prev_file="${proof}_poseidon_${sector_size}gib_b288702_${prev}_small_raw"
     if [[ ! -f ${prev_file} ]]; then
-        log "downloading params: ${file}"
+        log "downloading params: ${prev_file}"
         curl --progress-bar -O "${url_base}/${prev_file}"
     fi
     # Verify checksum even if file was present, in case of incomplete download


### PR DESCRIPTION
I also checked all other log messages about downloads.