### PR TITLE
fix: read files in text mode when hashing with b2sum

### DIFF
--- a/b288702/download_prereqs_for_contrib.sh
+++ b/b288702/download_prereqs_for_contrib.sh
@@ -83,7 +83,7 @@ if [[ ! -f './b288702.b2sums' ]]; then
     curl --progress-bar -O "${url_base}/b288702.b2sums"
 fi
 log 'verifying parameters checksums file checksum'
-echo "7931ca92df34bf0b6217692daaf2d92135fceb6caae344b10712ee997717cc612435b0a6e1e61325d5abaa62044b6f6359fd44bbe3dc4e111536bcad43c2e0ec b288702.b2sums" | b2sum -c
+echo "7931ca92df34bf0b6217692daaf2d92135fceb6caae344b10712ee997717cc612435b0a6e1e61325d5abaa62044b6f6359fd44bbe3dc4e111536bcad43c2e0ec  b288702.b2sums" | b2sum -c
 
 # Get the keyring with the public GPG keys to verify the signatures of the
 # contributions and put it into a local keyring.
@@ -92,7 +92,7 @@ if [[ ! -f './keyring.asc' ]]; then
     curl --progress-bar -O "${url_base}/keyring.asc"
 fi
 log 'verifying keyring with public GPG keys checksum'
-echo "5933fa0cebe764e02fbd394108af50169336bef01809df3d9004a0fe494bb0c48f1d67334b6b9de67b5185d0c0db78c01263d57675ce433df00a21258c845c8f keyring.asc" | b2sum -c
+echo "5933fa0cebe764e02fbd394108af50169336bef01809df3d9004a0fe494bb0c48f1d67334b6b9de67b5185d0c0db78c01263d57675ce433df00a21258c845c8f  keyring.asc" | b2sum -c
 if [[ ! -f './keyring.gpg' ]]; then
     gpg --no-default-keyring --keyring ./keyring.gpg --import keyring.asc
 else

--- a/b288702/download_prereqs_for_final.sh
+++ b/b288702/download_prereqs_for_final.sh
@@ -70,7 +70,7 @@ if [[ ! -f './b288702.b2sums' ]]; then
     curl --progress-bar -O "${url_base}/b288702.b2sums"
 fi
 log 'verifying parameters checksums file checksum'
-echo "7931ca92df34bf0b6217692daaf2d92135fceb6caae344b10712ee997717cc612435b0a6e1e61325d5abaa62044b6f6359fd44bbe3dc4e111536bcad43c2e0ec b288702.b2sums" | b2sum -c
+echo "7931ca92df34bf0b6217692daaf2d92135fceb6caae344b10712ee997717cc612435b0a6e1e61325d5abaa62044b6f6359fd44bbe3dc4e111536bcad43c2e0ec  b288702.b2sums" | b2sum -c
 
 
 initial_large="${proof}_poseidon_${sector_size}gib_b288702_0_large"

--- a/b288702/download_prereqs_for_initial_generation.sh
+++ b/b288702/download_prereqs_for_initial_generation.sh
@@ -75,4 +75,4 @@ if [[ ! -f ${phase1_file} ]]; then
     curl --progress-bar -O "${url_base_phase1}/${phase1_file}"
 fi
 log 'verifying Phase 1 checksum'
-echo "${phase1_checksum} ${phase1_file}" | b2sum -c
+echo "${phase1_checksum}  ${phase1_file}" | b2sum -c

--- a/b288702/generate_initial.sh
+++ b/b288702/generate_initial.sh
@@ -72,7 +72,7 @@ if [[ ! -f ${phase1_file} ]]; then
     exit 1
 fi
 log 'verifying Phase 1 checksum'
-echo "${phase1_checksum} ${phase1_file}" | b2sum -c
+echo "${phase1_checksum}  ${phase1_file}" | b2sum -c
 
 # Generate initial Phase 2 params.
 initial_large="${proof}_poseidon_${sector_size}gib_b288702_0_large"


### PR DESCRIPTION
When piping checksum lines to `b2sum -c` there should be two spaces between the expected digest and filename as opposed to one. This sets the read mode to "text".

Almost all Linux distros, as well as OSX, do not differentiate between text and binary files, and using a single space delimiter will default to text mode. However, it would be better to set this explicitly and to use the line format expected by the standard checksum utilities.
